### PR TITLE
feat: expose target_commitish from the release API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Name | Description
 --- | ---
 latest_tag | The latest release version tag
 latest_tag_published_at | The ISO8601 timestamp of when this version was released
+target_commitish | Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA.
 
 Example step
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,8 +5,9 @@ repo="$INPUT_REPO"
 
 release_json=$(curl https://api.github.com/repos/$owner/$repo/releases)
 latest_tag=$(echo "$release_json" | jq -r '.[0].tag_name')
-target_commitish=$(echo "$release_json" | jq -r '.[0].target_commitish')
 latest_tag_published_at=$(echo "$release_json" | jq -r '.[0].published_at')
+target_commitish=$(echo "$release_json" | jq -r '.[0].target_commitish')
 
 echo ::set-output name=latest_tag::"$latest_tag"
 echo ::set-output name=latest_tag_published_at::"$latest_tag_published_at"
+echo ::set-output name=target_commitish::"$target_commitish"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,7 @@ repo="$INPUT_REPO"
 
 release_json=$(curl https://api.github.com/repos/$owner/$repo/releases)
 latest_tag=$(echo "$release_json" | jq -r '.[0].tag_name')
+target_commitish=$(echo "$release_json" | jq -r '.[0].target_commitish')
 latest_tag_published_at=$(echo "$release_json" | jq -r '.[0].published_at')
 
 echo ::set-output name=latest_tag::"$latest_tag"


### PR DESCRIPTION
This exposes the branch or commit SHA used for the release.