### PR TITLE
fix: Tweak to use `/latest` endpoint

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,10 +30,10 @@ runs:
         owner="${{ inputs.owner }}"
         repo="${{ inputs.repo }}"
 
-        release_json=$(curl https://api.github.com/repos/$owner/$repo/releases)
-        latest_tag=$(echo "$release_json" | jq -r '.[0].tag_name')
-        latest_tag_published_at=$(echo "$release_json" | jq -r '.[0].published_at')
-        target_commitish=$(echo "$release_json" | jq -r '.[0].target_commitish')
+        release_json=$(curl https://api.github.com/repos/$owner/$repo/releases/latest)
+        latest_tag=$(echo "$release_json" | jq -r '.tag_name')
+        latest_tag_published_at=$(echo "$release_json" | jq -r '.published_at')
+        target_commitish=$(echo "$release_json" | jq -r '.target_commitish')
 
         echo "latest_tag: $latest_tag"
         echo "latest_tag_published_at: $latest_tag_published_at"


### PR DESCRIPTION
Fixes #11 by using `/latest` release endpoint.

Successful run is here: https://github.com/jamescooke/openapi-validator-docker/runs/4788020873?check_suite_focus=true