### PR TITLE
fix: Fail if commands in script fail

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ runs:
     - id: fetch-info
       shell: bash
       run: |
+        set -o errexit
+        set -o pipefail
+        
         owner="${{ inputs.owner }}"
         repo="${{ inputs.repo }}"
 


### PR DESCRIPTION
errexit: Exit immediately if a pipeline (which may consist of a single simple command), a list, or a compound command, exits with a non-zero  status.

pipefail: If set, the return value of a pipeline is the value of the last (rightmost) command to exit with a non-zero status, or zero if all commands in the pipeline exit successfully.

Fixes #23 (I think)